### PR TITLE
Feature/Signatures (Proof of concept)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # dependencies
 /node_modules
 
+# yarn files
+/.yarn
+/.yarnrc.yml
+
 # profiling files
 chrome-profiler-events*.json
 

--- a/angular.json
+++ b/angular.json
@@ -129,5 +129,8 @@
             }
         }
     },
-    "defaultProject": "thebananostand"
+    "defaultProject": "thebananostand",
+    "cli": {
+      "analytics": false
+    }
 }

--- a/src/app/animation.ts
+++ b/src/app/animation.ts
@@ -45,4 +45,6 @@ export const slideInAnimation = trigger('routeAnimations', [
     transition('Settings => *', slideOut),
     transition('* => AddressBook', slideIn),
     transition('AddressBook => *', slideOut),
+    transition('* => Signing', slideIn),
+    transition('Signing => *', slideOut),
 ]);

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ import { HomeComponent } from './pages/home/home.component';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { SettingsPageComponent } from '@app/pages/settings/settings.component';
+import { SigningComponent } from './pages/signing/signing.component';
 
 const routes: Routes = [
     { path: 'account/:account', component: AccountComponent, data: { animation: 'Account' }, canActivate: [AuthGuard] },
@@ -14,6 +15,12 @@ const routes: Routes = [
         path: 'address-book',
         component: AddressBookComponent,
         data: { animation: 'AddressBook' },
+        canActivate: [AuthGuard],
+    },
+    {
+        path: 'signing',
+        component: SigningComponent,
+        data: { animation: 'Signing' },
         canActivate: [AuthGuard],
     },
 ];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -73,6 +73,7 @@ import { SendBottomSheetComponent } from '@app/overlays/bottom-sheet/send/send-b
 import { SendComponent } from '@app/overlays/actions/send/send.component';
 import { SendDialogComponent } from '@app/overlays/dialogs/send/send-dialog.component';
 import { SpacerModule } from '@app/components/spacer/spacer.module';
+import { SigningComponent } from './pages/signing/signing.component';
 import { TransactionComponent } from '@app/pages/account/components/transaction/transaction.component';
 import { RenameAddressComponent } from '@app/overlays/actions/rename-address/rename-address.component';
 import { RenameAddressDialogComponent } from '@app/overlays/dialogs/rename-address/rename-address-dialog.component';
@@ -140,6 +141,7 @@ import { MatSliderModule } from '@angular/material/slider';
         SendComponent,
         SendDialogComponent,
         SettingsPageComponent,
+        SigningComponent,
         TransactionComponent,
         AccountTableComponent,
         AccountActionsComponent,

--- a/src/app/components/account-settings/account-settings.component.ts
+++ b/src/app/components/account-settings/account-settings.component.ts
@@ -32,6 +32,11 @@ import { AppStateService } from '@app/services/app-state.service';
                     <span>Address Book</span>
                 </button>
                 <mat-divider></mat-divider>
+                <button mat-menu-item (click)="navigateToSigning()">
+                    <mat-icon>edit_note</mat-icon>
+                    <span>Signing</span>
+                </button>
+                <mat-divider></mat-divider>
                 <button mat-menu-item (click)="navigateToSettingsPage()" data-cy="more-settings">
                     <mat-icon>open_in_new</mat-icon>
                     <span>More</span>
@@ -97,6 +102,13 @@ export class AppAccountSettingsComponent {
         this.userMenuOpen = false;
         setTimeout(() => {
             void this._router.navigate(['/address-book']);
+        }, 100);
+    }
+
+    navigateToSigning(): void {
+        this.userMenuOpen = false;
+        setTimeout(() => {
+            void this._router.navigate(['/signing']);
         }, 100);
     }
 

--- a/src/app/guards/auth-guard.ts
+++ b/src/app/guards/auth-guard.ts
@@ -15,7 +15,8 @@ export class AuthGuardService implements CanActivate {
         if (store.hasUnlockedLedger || store.hasUnlockedSecret) {
             return true;
         }
-        this.preservedRoute = window.location.pathname;
+        //preserve path and query string
+        this.preservedRoute = window.location.pathname+window.location.search;
         void this.router.navigate(['']);
         return false;
     }

--- a/src/app/guards/auth-guard.ts
+++ b/src/app/guards/auth-guard.ts
@@ -16,7 +16,7 @@ export class AuthGuardService implements CanActivate {
             return true;
         }
         //preserve path and query string
-        this.preservedRoute = window.location.pathname+window.location.search;
+        this.preservedRoute = window.location.pathname + window.location.search;
         void this.router.navigate(['']);
         return false;
     }

--- a/src/app/pages/signing/signing.component.html
+++ b/src/app/pages/signing/signing.component.html
@@ -1,0 +1,110 @@
+<div class="app-root app-signing-page" responsive>
+    <mat-toolbar color="primary" class="app-toolbar" responsive [class.mat-elevation-z2]="!vp.sm">
+        <div style="display: flex; align-items: center">
+            <button mat-icon-button (click)="back()">
+                <mat-icon style="color: var(--text-contrast)">close</mat-icon>
+            </button>
+            <span style="margin-left: 12px; color: var(--text-contrast)">Signing</span>
+        </div>
+    </mat-toolbar>
+
+    <div class="app-body" responsive>
+        <div class="app-body-content">
+            <!--Message signing-->
+            <mat-card
+                appearance="outlined"
+                style="margin: 16px 0; padding: 0; width: 100%"
+                [style.borderRadius.px]="vp.sm ? 0 : 16"
+            >
+                <div style="padding: 24px 24px; display: flex; justify-content: space-between; align-items: center">
+                    <div class="mat-headline-6">Message Signing</div>
+                    <div
+                    style="display: flex; justify-content: space-between"
+                    [style.width.%]="vp.sm ? 100 : undefined"
+                    >
+                        <button mat-button (click)="toggleMessageSignExpand()">
+                            <mat-icon>expand</mat-icon>
+                            <span>{{ messageSignExpand ? "Shrink" : "Expand" }}</span>
+                        </button>
+                    </div>
+                </div>
+                <div style="padding: 24px 24px;" *ngIf="messageSignExpand">
+                    <div *ngIf="store.hasSecret">
+                        <div class="mat-subtitle-2" style="padding-bottom: 16px;">
+                            Messages can be signed with your private key, verifying your identity without revealing your private key and putting your funds in danger. For security reasons, signed message must start with "message-".
+                        </div>
+                        <form>
+                            <!--Choose address dropdown-->
+                            <mat-form-field style="width: 100%" appearance="fill">
+                                <mat-select placeholder="Signing address" [formControl]="addressFormControl" required>
+                                    <mat-option *ngFor="let account of store.accounts" [value]="account.index">
+                                        {{ account.shortAddress }} (Index: {{ account.index }})
+                                    </mat-option>
+                                </mat-select>
+                            </mat-form-field>
+                            <!--Put in message (that has "message-" prepended)-->
+                            <mat-form-field style="width: 100%" appearance="fill">
+                                <mat-label>Message</mat-label>
+                                <input
+                                    matInput
+                                    name="message"
+                                    autocomplete="off"
+                                    [type]="text"
+                                    value="message-"
+                                    (change)="message"
+                                    [formControl]="messageFormControl"
+                                    required
+                                />
+                            </mat-form-field>
+                        </form>
+                        <button mat-flat-button color="primary" matTooltip="Sign the message with the account's private key" (click)="goSignMessage()">
+                            Sign
+                        </button>
+                        <div *ngIf="messageSignature !== ''" style="padding-top: 16px;">
+                            <mat-form-field style="width: 80%" appearance="fill">
+                                <mat-label>Signature</mat-label>
+                                <input matInput [value]="messageSignature" disabled>
+                            </mat-form-field>
+                            <button
+                                mat-icon-button
+                                (click)="copyMessageSignature()"
+                                style="margin-left: 8px"
+                                *ngIf="!vp.sm"
+                                data-cy="copy-address-desktop"
+                            >
+                                <mat-icon>
+                                    {{ hasCopiedMessageSignature ? 'check_circle' : 'content_copy' }}
+                                </mat-icon>
+                            </button>
+                        </div>
+                    </div>
+                    <!-- iirc message signing on ledger not possible because the bananojs-hw does not support it -->
+                    <div *ngIf="!store.hasSecret">
+                        <div class="mat-body-2">
+                            Message signing not available with ledger, sorry. For message signing, please use a browser wallet.
+                        </div>
+                    </div>
+                </div>
+            </mat-card>
+            <!--Block signing-->
+            <mat-card
+                appearance="outlined"
+                style="margin: 16px 0; padding: 0; width: 100%"
+                [style.borderRadius.px]="vp.sm ? 0 : 16"
+            >
+                <div style="padding: 24px 24px; display: flex; justify-content: space-between; align-items: center">
+                    <div class="mat-headline-6">Block Signing</div>
+                    <div
+                      style="display: flex; justify-content: space-between"
+                      [style.width.%]="vp.sm ? 100 : undefined"
+                    >
+                        <button mat-button (click)="toggleBlockSignExpand()">
+                            <mat-icon>expand</mat-icon>
+                            <span>{{ blockSignExpand ? "Shrink" : "Expand" }}</span>
+                        </button>
+                    </div>
+                </div>
+            </mat-card>
+        </div>
+    </div>
+</div>

--- a/src/app/pages/signing/signing.component.html
+++ b/src/app/pages/signing/signing.component.html
@@ -19,19 +19,21 @@
                 <div style="padding: 24px 24px; display: flex; justify-content: space-between; align-items: center">
                     <div class="mat-headline-6">Message Signing</div>
                     <div
-                    style="display: flex; justify-content: space-between"
-                    [style.width.%]="vp.sm ? 100 : undefined"
+                        style="display: flex; justify-content: space-between"
+                        [style.width.%]="vp.sm ? 100 : undefined"
                     >
                         <button mat-button (click)="toggleMessageSignExpand()">
                             <mat-icon>expand</mat-icon>
-                            <span>{{ messageSignExpand ? "Shrink" : "Expand" }}</span>
+                            <span>{{ messageSignExpand ? 'Shrink' : 'Expand' }}</span>
                         </button>
                     </div>
                 </div>
-                <div style="padding: 0px 24px 24px 24px;" *ngIf="messageSignExpand">
+                <div style="padding: 0px 24px 24px 24px" *ngIf="messageSignExpand">
                     <div *ngIf="store.hasSecret">
-                        <div class="mat-subtitle-2" style="padding-bottom: 16px;">
-                            Messages can be signed with your private key, verifying your identity without revealing your private key and putting your funds in danger. For security reasons, signed message must start with "message-", and can not be exactly 32 characters.
+                        <div class="mat-subtitle-2" style="padding-bottom: 16px">
+                            Messages can be signed with your private key, verifying your identity without revealing your
+                            private key and putting your funds in danger. For security reasons, signed message must
+                            start with "message-", and can not be exactly 32 characters.
                         </div>
                         <form>
                             <!--Choose address dropdown-->
@@ -56,13 +58,18 @@
                                 />
                             </mat-form-field>
                         </form>
-                        <button mat-flat-button color="primary" matTooltip="Sign the message with the account's private key" (click)="goSignMessage()">
+                        <button
+                            mat-flat-button
+                            color="primary"
+                            matTooltip="Sign the message with the account's private key"
+                            (click)="goSignMessage()"
+                        >
                             Sign
                         </button>
-                        <div *ngIf="messageSignature !== ''" style="padding-top: 16px;">
+                        <div *ngIf="messageSignature !== ''" style="padding-top: 16px">
                             <mat-form-field style="width: 80%" appearance="fill">
                                 <mat-label>Signature</mat-label>
-                                <input matInput [value]="messageSignature" disabled>
+                                <input matInput [value]="messageSignature" disabled />
                             </mat-form-field>
                             <button
                                 mat-icon-button
@@ -80,7 +87,8 @@
                     <!-- iirc message signing on ledger not possible because the bananojs-hw does not support it -->
                     <div *ngIf="!store.hasSecret">
                         <div class="mat-body-2">
-                            Message signing not available with ledger, sorry. For message signing, please use a browser wallet.
+                            Message signing not available with ledger, sorry. For message signing, please use a browser
+                            wallet.
                         </div>
                     </div>
                 </div>
@@ -94,17 +102,17 @@
                 <div style="padding: 24px 24px; display: flex; justify-content: space-between; align-items: center">
                     <div class="mat-headline-6">Message Verification</div>
                     <div
-                      style="display: flex; justify-content: space-between"
-                      [style.width.%]="vp.sm ? 100 : undefined"
+                        style="display: flex; justify-content: space-between"
+                        [style.width.%]="vp.sm ? 100 : undefined"
                     >
                         <button mat-button (click)="toggleMessageVerifyExpand()">
                             <mat-icon>expand</mat-icon>
-                            <span>{{ messageVerifyExpand ? "Shrink" : "Expand" }}</span>
+                            <span>{{ messageVerifyExpand ? 'Shrink' : 'Expand' }}</span>
                         </button>
                     </div>
                 </div>
-                <div style="padding: 0px 24px 24px 24px;" *ngIf="messageVerifyExpand">
-                    <div class="mat-subtitle-2" style="padding-bottom: 16px;">
+                <div style="padding: 0px 24px 24px 24px" *ngIf="messageVerifyExpand">
+                    <div class="mat-subtitle-2" style="padding-bottom: 16px">
                         Verify that the signature for a message was made by the private key owner of the address.
                     </div>
                     <form>
@@ -144,8 +152,13 @@
                                 required
                             />
                         </mat-form-field>
-                        <button mat-flat-button [color]="verify_button_color" matTooltip="Verify that the signature is valid" (click)="verifySign()">
-                            {{ verify_button_text }}
+                        <button
+                            mat-flat-button
+                            [color]="verifyButtonColor"
+                            matTooltip="Verify that the signature is valid"
+                            (click)="verifySign()"
+                        >
+                            {{ verifyButtonText }}
                         </button>
                     </form>
                 </div>
@@ -159,18 +172,20 @@
                 <div style="padding: 24px 24px; display: flex; justify-content: space-between; align-items: center">
                     <div class="mat-headline-6">Block Signing</div>
                     <div
-                      style="display: flex; justify-content: space-between"
-                      [style.width.%]="vp.sm ? 100 : undefined"
+                        style="display: flex; justify-content: space-between"
+                        [style.width.%]="vp.sm ? 100 : undefined"
                     >
                         <button mat-button (click)="toggleBlockSignExpand()">
                             <mat-icon>expand</mat-icon>
-                            <span>{{ blockSignExpand ? "Shrink" : "Expand" }}</span>
+                            <span>{{ blockSignExpand ? 'Shrink' : 'Expand' }}</span>
                         </button>
                     </div>
                 </div>
-                <div style="padding: 0px 24px 24px 24px;" *ngIf="blockSignExpand">
-                    <div class="mat-subtitle-2" style="padding-bottom: 16px;">
-                        This is a DANGEROUS ACTION. Signing blocks that you do not understand may result in LOSS OF FUNDS. Only sign blocks you understand, and trust! Giving others the signature for a block will let them broadcast the block on your behalf.
+                <div style="padding: 0px 24px 24px 24px" *ngIf="blockSignExpand">
+                    <div class="mat-subtitle-2" style="padding-bottom: 16px">
+                        This is a DANGEROUS ACTION. Signing blocks that you do not understand may result in LOSS OF
+                        FUNDS. Only sign blocks you understand, and trust! Giving others the signature for a block will
+                        let them broadcast the block on your behalf.
                     </div>
                     <form>
                         <mat-form-field style="width: 100%" appearance="fill">
@@ -229,13 +244,18 @@
                             />
                         </mat-form-field>
                     </form>
-                    <button mat-flat-button color="warn" matTooltip="Sign the block. Warning: only sign blocks you understand!" (click)="goSignBlock()">
+                    <button
+                        mat-flat-button
+                        color="warn"
+                        matTooltip="Sign the block. Warning: only sign blocks you understand!"
+                        (click)="goSignBlock()"
+                    >
                         Sign (Caution)
                     </button>
-                    <div *ngIf="blockSignature !== ''" style="padding-top: 16px;">
+                    <div *ngIf="blockSignature !== ''" style="padding-top: 16px">
                         <mat-form-field style="width: 80%" appearance="fill">
                             <mat-label>Signature</mat-label>
-                            <input matInput [value]="blockSignature" disabled>
+                            <input matInput [value]="blockSignature" disabled />
                         </mat-form-field>
                         <button
                             mat-icon-button

--- a/src/app/pages/signing/signing.component.html
+++ b/src/app/pages/signing/signing.component.html
@@ -28,10 +28,10 @@
                         </button>
                     </div>
                 </div>
-                <div style="padding: 24px 24px;" *ngIf="messageSignExpand">
+                <div style="padding: 0px 24px 24px 24px;" *ngIf="messageSignExpand">
                     <div *ngIf="store.hasSecret">
                         <div class="mat-subtitle-2" style="padding-bottom: 16px;">
-                            Messages can be signed with your private key, verifying your identity without revealing your private key and putting your funds in danger. For security reasons, signed message must start with "message-".
+                            Messages can be signed with your private key, verifying your identity without revealing your private key and putting your funds in danger. For security reasons, signed message must start with "message-", and can not be exactly 32 characters.
                         </div>
                         <form>
                             <!--Choose address dropdown-->
@@ -51,7 +51,6 @@
                                     autocomplete="off"
                                     [type]="text"
                                     value="message-"
-                                    (change)="message"
                                     [formControl]="messageFormControl"
                                     required
                                 />
@@ -86,6 +85,71 @@
                     </div>
                 </div>
             </mat-card>
+            <!--Signature verification-->
+            <mat-card
+                appearance="outlined"
+                style="margin: 16px 0; padding: 0; width: 100%"
+                [style.borderRadius.px]="vp.sm ? 0 : 16"
+            >
+                <div style="padding: 24px 24px; display: flex; justify-content: space-between; align-items: center">
+                    <div class="mat-headline-6">Message Verification</div>
+                    <div
+                      style="display: flex; justify-content: space-between"
+                      [style.width.%]="vp.sm ? 100 : undefined"
+                    >
+                        <button mat-button (click)="toggleMessageVerifyExpand()">
+                            <mat-icon>expand</mat-icon>
+                            <span>{{ messageVerifyExpand ? "Shrink" : "Expand" }}</span>
+                        </button>
+                    </div>
+                </div>
+                <div style="padding: 0px 24px 24px 24px;" *ngIf="messageVerifyExpand">
+                    <div class="mat-subtitle-2" style="padding-bottom: 16px;">
+                        Verify that the signature for a message was made by the private key owner of the address.
+                    </div>
+                    <form>
+                        <!--Address input-->
+                        <mat-form-field style="width: 100%" appearance="fill">
+                            <mat-label>Signer Address</mat-label>
+                            <input
+                                matInput
+                                name="signer-address"
+                                autocomplete="off"
+                                [type]="text"
+                                [formControl]="signerFormControl"
+                                required
+                            />
+                        </mat-form-field>
+                        <!--Message input-->
+                        <mat-form-field style="width: 100%" appearance="fill">
+                            <mat-label>Message</mat-label>
+                            <input
+                                matInput
+                                name="verify-message"
+                                autocomplete="off"
+                                [type]="text"
+                                [formControl]="verifyMessageFormControl"
+                                required
+                            />
+                        </mat-form-field>
+                        <!--Signature input-->
+                        <mat-form-field style="width: 100%" appearance="fill">
+                            <mat-label>Signature</mat-label>
+                            <input
+                                matInput
+                                name="verify-sign"
+                                autocomplete="off"
+                                [type]="text"
+                                [formControl]="verifySignFormControl"
+                                required
+                            />
+                        </mat-form-field>
+                        <button mat-flat-button [color]="verify_button_color" matTooltip="Verify that the signature is valid" (click)="verifySign()">
+                            {{ verify_button_text }}
+                        </button>
+                    </form>
+                </div>
+            </mat-card>
             <!--Block signing-->
             <mat-card
                 appearance="outlined"
@@ -101,6 +165,88 @@
                         <button mat-button (click)="toggleBlockSignExpand()">
                             <mat-icon>expand</mat-icon>
                             <span>{{ blockSignExpand ? "Shrink" : "Expand" }}</span>
+                        </button>
+                    </div>
+                </div>
+                <div style="padding: 0px 24px 24px 24px;" *ngIf="blockSignExpand">
+                    <div class="mat-subtitle-2" style="padding-bottom: 16px;">
+                        This is a DANGEROUS ACTION. Signing blocks that you do not understand may result in LOSS OF FUNDS. Only sign blocks you understand, and trust! Giving others the signature for a block will let them broadcast the block on your behalf.
+                    </div>
+                    <form>
+                        <mat-form-field style="width: 100%" appearance="fill">
+                            <mat-select placeholder="Signing address" [formControl]="addressBlockFormControl" required>
+                                <mat-option *ngFor="let account of store.accounts" [value]="account.index">
+                                    {{ account.shortAddress }} (Index: {{ account.index }})
+                                </mat-option>
+                            </mat-select>
+                        </mat-form-field>
+                        <mat-form-field style="width: 100%" appearance="fill">
+                            <mat-label>Previous</mat-label>
+                            <input
+                                matInput
+                                name="previous"
+                                autocomplete="off"
+                                placeholder="Hash of previous block"
+                                [type]="text"
+                                [formControl]="previousFormControl"
+                                required
+                            />
+                        </mat-form-field>
+                        <mat-form-field style="width: 100%" appearance="fill">
+                            <mat-label>Representative</mat-label>
+                            <input
+                                matInput
+                                name="representative"
+                                autocomplete="off"
+                                placeholder="Banano Representative"
+                                [type]="text"
+                                [formControl]="representativeFormControl"
+                                required
+                            />
+                        </mat-form-field>
+                        <mat-form-field style="width: 100%" appearance="fill">
+                            <mat-label>Balance</mat-label>
+                            <input
+                                matInput
+                                name="balance"
+                                autocomplete="off"
+                                placeholder="Balance of account in raw"
+                                [type]="number"
+                                [formControl]="balanceFormControl"
+                                required
+                            />
+                        </mat-form-field>
+                        <mat-form-field style="width: 100%" appearance="fill">
+                            <mat-label>Link</mat-label>
+                            <input
+                                matInput
+                                name="link"
+                                autocomplete="off"
+                                placeholder="Link (hexadecimal)"
+                                [type]="text"
+                                [formControl]="linkFormControl"
+                                required
+                            />
+                        </mat-form-field>
+                    </form>
+                    <button mat-flat-button color="warn" matTooltip="Sign the block. Warning: only sign blocks you understand!" (click)="goSignBlock()">
+                        Sign (Caution)
+                    </button>
+                    <div *ngIf="blockSignature !== ''" style="padding-top: 16px;">
+                        <mat-form-field style="width: 80%" appearance="fill">
+                            <mat-label>Signature</mat-label>
+                            <input matInput [value]="blockSignature" disabled>
+                        </mat-form-field>
+                        <button
+                            mat-icon-button
+                            (click)="copyBlockSignature()"
+                            style="margin-left: 8px"
+                            *ngIf="!vp.sm"
+                            data-cy="copy-address-desktop"
+                        >
+                            <mat-icon>
+                                {{ hasCopiedBlockSignature ? 'check_circle' : 'content_copy' }}
+                            </mat-icon>
                         </button>
                     </div>
                 </div>

--- a/src/app/pages/signing/signing.component.ts
+++ b/src/app/pages/signing/signing.component.ts
@@ -1,0 +1,75 @@
+import { Component, OnInit, Pipe, PipeTransform } from '@angular/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+//import { animate, style, transition, trigger } from '@angular/animations';
+import { ViewportService } from '@app/services/viewport.service';
+import { Location } from '@angular/common';
+import { UtilService } from '@app/services/util.service';
+import { AppStateService, AppStore } from '@app/services/app-state.service';
+import { FormControl, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { TransactionService } from '@app/services/transaction.service';
+
+@UntilDestroy()
+@Component({
+    selector: 'app-signing-page',
+    templateUrl: './signing.component.html',
+    //styleUrls: [],
+})
+export class SigningComponent {
+    store: AppStore;
+    transactionService: TransactionService;
+
+    messageFormControl = new FormControl('message-', [
+        (control: AbstractControl): ValidationErrors | null => {
+            const forbidden = !control.value.startsWith("message-");
+            return forbidden ? {forbiddenName: {value: control.value}} : null;
+        }
+    ]);
+    addressFormControl = new FormControl(0);
+
+    messageSignExpand = false;
+    blockSignExpand = false;
+    hasCopiedMessageSignature = false;
+    messageSignature: string = "";
+
+    constructor(
+      public vp: ViewportService,
+      public util: UtilService,
+      private readonly _location: Location,
+      private readonly _transactionService: TransactionService,
+      private readonly _appStateService: AppStateService,
+    ) {
+        this.transactionService = _transactionService;
+        _appStateService.store.pipe(untilDestroyed(this)).subscribe((store) => {
+          this.store = store;
+          this.store.activeWallet.loadedIndexes
+          console.log(this.store.accounts)
+        });
+    }
+
+    async goSignMessage(): Promise<void> {
+        const message: string = this.messageFormControl.value;
+        if (!message.startsWith("message-")) return;
+        let accountIndex: number = this.addressFormControl.value;
+        this.messageSignature = await this.transactionService.messageSign(message, accountIndex);
+    }
+
+    copyMessageSignature(): void {
+        this.util.clipboardCopy(this.messageSignature);
+        this.hasCopiedMessageSignature = true;
+        setTimeout(() => {
+            this.hasCopiedMessageSignature = false;
+        }, 690);
+    }
+
+    toggleMessageSignExpand(): void {
+        this.messageSignExpand = this.messageSignExpand ? false : true;
+    }
+
+    toggleBlockSignExpand(): void {
+        this.blockSignExpand = this.blockSignExpand ? false : true;
+    }
+
+    back(): void {
+      this._location.back();
+    }
+}

--- a/src/app/pages/signing/signing.component.ts
+++ b/src/app/pages/signing/signing.component.ts
@@ -1,12 +1,12 @@
-import { Component, OnInit, Pipe, PipeTransform } from '@angular/core';
+import { Component } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 //import { animate, style, transition, trigger } from '@angular/animations';
 import { ViewportService } from '@app/services/viewport.service';
 import { Location } from '@angular/common';
 import { UtilService } from '@app/services/util.service';
 import { AppStateService, AppStore } from '@app/services/app-state.service';
-import { FormControl, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
-import { ActivatedRoute } from "@angular/router";
+import { FormControl, AbstractControl, ValidationErrors } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { TransactionService } from '@app/services/transaction.service';
 import { AccountOverview } from '@app/types/AccountOverview';
 import { TransactionBlock } from '@app/types/TransactionBlock';
@@ -23,113 +23,117 @@ export class SigningComponent {
 
     messageFormControl = new FormControl('message-', [
         (control: AbstractControl): ValidationErrors | null => {
-            const forbidden = !control.value.startsWith("message-") || control.value.length === 32;
-            return forbidden ? {forbiddenName: {value: control.value}} : null;
-        }
+            const forbidden = !control.value.startsWith('message-') || control.value.length === 32;
+            return forbidden ? { forbiddenName: { value: control.value } } : null;
+        },
     ]);
     addressFormControl = new FormControl(0);
 
-    signerFormControl = new FormControl("", [
-        (control: AbstractControl): ValidationErrors | null => {
-            const forbidden = !this.util.isValidAddress(control.value)            ;
-            return forbidden ? {forbiddenName: {value: control.value}} : null;
-        }
-    ]);
-    verifyMessageFormControl = new FormControl("");
-    verifySignFormControl = new FormControl("");
-    verify_button_text = "Verify";
-    verify_button_color = "primary";
-
-    addressBlockFormControl = new FormControl(0);
-    previousFormControl = new FormControl("", [
-        (control: AbstractControl): ValidationErrors | null => {
-            const forbidden = control.value.length !== 64 || !this.util.isValidHex(control.value);
-            return forbidden ? {forbiddenName: {value: control.value}} : null;
-        }
-    ]);
-    representativeFormControl = new FormControl("", [
+    signerFormControl = new FormControl('', [
         (control: AbstractControl): ValidationErrors | null => {
             const forbidden = !this.util.isValidAddress(control.value);
-            return forbidden ? {forbiddenName: {value: control.value}} : null;
-        }
+            return forbidden ? { forbiddenName: { value: control.value } } : null;
+        },
     ]);
-    balanceFormControl = new FormControl("", [
-        (control: AbstractControl): ValidationErrors | null => {
-            const forbidden = isNaN(Number(control.value));
-            return forbidden ? {forbiddenName: {value: control.value}} : null;
-        }
-    ]);
-    linkFormControl = new FormControl("", [
+    verifyMessageFormControl = new FormControl('');
+    verifySignFormControl = new FormControl('');
+    verifyButtonText = 'Verify';
+    verifyButtonColor = 'primary';
+
+    addressBlockFormControl = new FormControl(0);
+    previousFormControl = new FormControl('', [
         (control: AbstractControl): ValidationErrors | null => {
             const forbidden = control.value.length !== 64 || !this.util.isValidHex(control.value);
-            return forbidden ? {forbiddenName: {value: control.value}} : null;
-        }
+            return forbidden ? { forbiddenName: { value: control.value } } : null;
+        },
+    ]);
+    representativeFormControl = new FormControl('', [
+        (control: AbstractControl): ValidationErrors | null => {
+            const forbidden = !this.util.isValidAddress(control.value);
+            return forbidden ? { forbiddenName: { value: control.value } } : null;
+        },
+    ]);
+    balanceFormControl = new FormControl('', [
+        (control: AbstractControl): ValidationErrors | null => {
+            const forbidden = isNaN(Number(control.value));
+            return forbidden ? { forbiddenName: { value: control.value } } : null;
+        },
+    ]);
+    linkFormControl = new FormControl('', [
+        (control: AbstractControl): ValidationErrors | null => {
+            const forbidden = control.value.length !== 64 || !this.util.isValidHex(control.value);
+            return forbidden ? { forbiddenName: { value: control.value } } : null;
+        },
     ]);
 
     messageSignExpand = false;
     messageVerifyExpand = false;
     blockSignExpand = false;
     hasCopiedMessageSignature = false;
-    messageSignature: string = "";
-    blockSignature: string = "";
+    messageSignature = '';
+    blockSignature = '';
     hasCopiedBlockSignature = false;
 
     constructor(
-      public vp: ViewportService,
-      public util: UtilService,
-      private readonly _location: Location,
-      private readonly _transactionService: TransactionService,
-      private readonly _appStateService: AppStateService,
-      private route: ActivatedRoute,
+        public vp: ViewportService,
+        public util: UtilService,
+        private readonly _location: Location,
+        private readonly _transactionService: TransactionService,
+        private readonly _appStateService: AppStateService,
+        private readonly _route: ActivatedRoute
     ) {
         this.transactionService = _transactionService;
         _appStateService.store.pipe(untilDestroyed(this)).subscribe((store) => {
-          this.store = store;
-          this.route.queryParams.subscribe(params => {
-              if (params.request === "message_sign") {
-                  if (params.address) {
-                      let found_account: AccountOverview[] = this.store.accounts.filter((account) => account.fullAddress === params.address);
-                      if (found_account[0]) {
-                          this.addressFormControl.setValue(found_account[0].index);
-                      }
-                  }
-                  if (params.message.startsWith("message-")) {
-                      this.messageFormControl.setValue(params.message);
-                  }
-                  this.messageSignExpand = true;
-              } else if (params.request === "block_sign") {
-                  if (params.address) {
-                      let found_account: AccountOverview[] = this.store.accounts.filter((account) => account.fullAddress === params.address);
-                      if (found_account[0]) {
-                          this.addressFormControl.setValue(found_account[0].index);
-                      }
-                  }
-                  //must be valid 32 byte hex
-                  if (params.previous && params.previous.length === 64 && this.util.isValidHex(params.previous)) {
-                      this.previousFormControl.setValue(params.previous);
-                  }
-                  //rep must be a valid banano address
-                  if (params.representative && this.util.isValidAddress(params.representative)) {
-                      this.representativeFormControl.setValue(params.representative);
-                  }
-                  //balance must be a valid number, in raw
-                  if (params.balance && !isNaN(Number(params.balance))) {
-                      this.balanceFormControl.setValue(params.balance);
-                  }
-                  //must be valid 32 byte hex
-                  if (params.link && params.link.length === 64 && this.util.isValidHex(params.link)) {
-                      this.linkFormControl.setValue(params.link);
-                  }
-                  this.blockSignExpand = true;
-              }
-          });
+            this.store = store;
+            this._route.queryParams.subscribe((params) => {
+                if (params.request === 'message_sign') {
+                    if (params.address) {
+                        const foundAccount: AccountOverview[] = this.store.accounts.filter(
+                            (account) => account.fullAddress === params.address
+                        );
+                        if (foundAccount[0]) {
+                            this.addressFormControl.setValue(foundAccount[0].index);
+                        }
+                    }
+                    if (params.message.startsWith('message-')) {
+                        this.messageFormControl.setValue(params.message);
+                    }
+                    this.messageSignExpand = true;
+                } else if (params.request === 'block_sign') {
+                    if (params.address) {
+                        const foundAccount: AccountOverview[] = this.store.accounts.filter(
+                            (account) => account.fullAddress === params.address
+                        );
+                        if (foundAccount[0]) {
+                            this.addressFormControl.setValue(foundAccount[0].index);
+                        }
+                    }
+                    //must be valid 32 byte hex
+                    if (params.previous && params.previous.length === 64 && this.util.isValidHex(params.previous)) {
+                        this.previousFormControl.setValue(params.previous);
+                    }
+                    //rep must be a valid banano address
+                    if (params.representative && this.util.isValidAddress(params.representative)) {
+                        this.representativeFormControl.setValue(params.representative);
+                    }
+                    //balance must be a valid number, in raw
+                    if (params.balance && !isNaN(Number(params.balance))) {
+                        this.balanceFormControl.setValue(params.balance);
+                    }
+                    //must be valid 32 byte hex
+                    if (params.link && params.link.length === 64 && this.util.isValidHex(params.link)) {
+                        this.linkFormControl.setValue(params.link);
+                    }
+                    this.blockSignExpand = true;
+                }
+            });
         });
     }
 
     async goSignMessage(): Promise<void> {
         const message: string = this.messageFormControl.value;
-        if (!message.startsWith("message-") || message.length === 32) return;
-        let accountIndex: number = this.addressFormControl.value;
+        if (!message.startsWith('message-') || message.length === 32) return;
+        const accountIndex: number = this.addressFormControl.value;
         this.messageSignature = await this.transactionService.messageSign(message, accountIndex);
     }
 
@@ -150,39 +154,39 @@ export class SigningComponent {
     }
 
     verifySign(): void {
-        let signerAddress = this.signerFormControl.value;
+        const signerAddress = this.signerFormControl.value;
         if (!this.util.isValidAddress(signerAddress)) return;
-        let message = this.verifyMessageFormControl.value;
-        let sign = this.verifySignFormControl.value;
-        if (signerAddress === "" || message === "" || sign === "") return;
+        const message = this.verifyMessageFormControl.value;
+        const sign = this.verifySignFormControl.value;
+        if (signerAddress === '' || message === '' || sign === '') return;
         let valid: boolean;
         try {
-          valid = this.transactionService.verifySign(signerAddress, message, sign);
+            valid = this.transactionService.verifySign(signerAddress, message, sign);
         } catch (e) {
-          valid = false;
+            valid = false;
         }
         if (valid) {
-            this.verify_button_text = "Valid";
-            this.verify_button_color = "accent";
+            this.verifyButtonText = 'Valid';
+            this.verifyButtonColor = 'accent';
         } else {
-            this.verify_button_text = "Invalid";
-            this.verify_button_color = "warn";
+            this.verifyButtonText = 'Invalid';
+            this.verifyButtonColor = 'warn';
         }
         setTimeout(() => {
-            this.verify_button_text = "Verify";
-            this.verify_button_color = "primary";
+            this.verifyButtonText = 'Verify';
+            this.verifyButtonColor = 'primary';
         }, 1200);
     }
 
     async goSignBlock(): Promise<void> {
-        let accountIndex: number = this.addressBlockFormControl.value;
-        let previous: string = this.previousFormControl.value;
+        const accountIndex: number = this.addressBlockFormControl.value;
+        const previous: string = this.previousFormControl.value;
         if (previous.length !== 64 || !this.util.isValidHex(previous)) return;
-        let representative: string = this.representativeFormControl.value;
+        const representative: string = this.representativeFormControl.value;
         if (!this.util.isValidAddress(representative)) return;
-        let rawBalance: string = this.balanceFormControl.value;
+        const rawBalance: string = this.balanceFormControl.value;
         if (isNaN(Number(rawBalance))) return;
-        let link: string = this.linkFormControl.value;
+        const link: string = this.linkFormControl.value;
         if (link.length !== 64 || !this.util.isValidHex(link)) return;
         const block: TransactionBlock = {
             type: 'state',
@@ -210,6 +214,6 @@ export class SigningComponent {
     }
 
     back(): void {
-      this._location.back();
+        this._location.back();
     }
 }

--- a/src/app/pages/signing/signing.component.ts
+++ b/src/app/pages/signing/signing.component.ts
@@ -6,7 +6,10 @@ import { Location } from '@angular/common';
 import { UtilService } from '@app/services/util.service';
 import { AppStateService, AppStore } from '@app/services/app-state.service';
 import { FormControl, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { ActivatedRoute } from "@angular/router";
 import { TransactionService } from '@app/services/transaction.service';
+import { AccountOverview } from '@app/types/AccountOverview';
+import { TransactionBlock } from '@app/types/TransactionBlock';
 
 @UntilDestroy()
 @Component({
@@ -20,16 +23,56 @@ export class SigningComponent {
 
     messageFormControl = new FormControl('message-', [
         (control: AbstractControl): ValidationErrors | null => {
-            const forbidden = !control.value.startsWith("message-");
+            const forbidden = !control.value.startsWith("message-") || control.value.length === 32;
             return forbidden ? {forbiddenName: {value: control.value}} : null;
         }
     ]);
     addressFormControl = new FormControl(0);
 
+    signerFormControl = new FormControl("", [
+        (control: AbstractControl): ValidationErrors | null => {
+            const forbidden = !this.util.isValidAddress(control.value)            ;
+            return forbidden ? {forbiddenName: {value: control.value}} : null;
+        }
+    ]);
+    verifyMessageFormControl = new FormControl("");
+    verifySignFormControl = new FormControl("");
+    verify_button_text = "Verify";
+    verify_button_color = "primary";
+
+    addressBlockFormControl = new FormControl(0);
+    previousFormControl = new FormControl("", [
+        (control: AbstractControl): ValidationErrors | null => {
+            const forbidden = control.value.length !== 64 || !this.util.isValidHex(control.value);
+            return forbidden ? {forbiddenName: {value: control.value}} : null;
+        }
+    ]);
+    representativeFormControl = new FormControl("", [
+        (control: AbstractControl): ValidationErrors | null => {
+            const forbidden = !this.util.isValidAddress(control.value);
+            return forbidden ? {forbiddenName: {value: control.value}} : null;
+        }
+    ]);
+    balanceFormControl = new FormControl("", [
+        (control: AbstractControl): ValidationErrors | null => {
+            const forbidden = isNaN(Number(control.value));
+            return forbidden ? {forbiddenName: {value: control.value}} : null;
+        }
+    ]);
+    linkFormControl = new FormControl("", [
+        (control: AbstractControl): ValidationErrors | null => {
+            const forbidden = control.value.length !== 64 || !this.util.isValidHex(control.value);
+            return forbidden ? {forbiddenName: {value: control.value}} : null;
+        }
+    ]);
+
     messageSignExpand = false;
+    messageVerifyExpand = false;
     blockSignExpand = false;
     hasCopiedMessageSignature = false;
     messageSignature: string = "";
+    blockSignature: string = "";
+    hasCopiedBlockSignature = false;
 
     constructor(
       public vp: ViewportService,
@@ -37,18 +80,55 @@ export class SigningComponent {
       private readonly _location: Location,
       private readonly _transactionService: TransactionService,
       private readonly _appStateService: AppStateService,
+      private route: ActivatedRoute,
     ) {
         this.transactionService = _transactionService;
         _appStateService.store.pipe(untilDestroyed(this)).subscribe((store) => {
           this.store = store;
-          this.store.activeWallet.loadedIndexes
-          console.log(this.store.accounts)
+          this.route.queryParams.subscribe(params => {
+              if (params.request === "message_sign") {
+                  if (params.address) {
+                      let found_account: AccountOverview[] = this.store.accounts.filter((account) => account.fullAddress === params.address);
+                      if (found_account[0]) {
+                          this.addressFormControl.setValue(found_account[0].index);
+                      }
+                  }
+                  if (params.message.startsWith("message-")) {
+                      this.messageFormControl.setValue(params.message);
+                  }
+                  this.messageSignExpand = true;
+              } else if (params.request === "block_sign") {
+                  if (params.address) {
+                      let found_account: AccountOverview[] = this.store.accounts.filter((account) => account.fullAddress === params.address);
+                      if (found_account[0]) {
+                          this.addressFormControl.setValue(found_account[0].index);
+                      }
+                  }
+                  //must be valid 32 byte hex
+                  if (params.previous && params.previous.length === 64 && this.util.isValidHex(params.previous)) {
+                      this.previousFormControl.setValue(params.previous);
+                  }
+                  //rep must be a valid banano address
+                  if (params.representative && this.util.isValidAddress(params.representative)) {
+                      this.representativeFormControl.setValue(params.representative);
+                  }
+                  //balance must be a valid number, in raw
+                  if (params.balance && !isNaN(Number(params.balance))) {
+                      this.balanceFormControl.setValue(params.balance);
+                  }
+                  //must be valid 32 byte hex
+                  if (params.link && params.link.length === 64 && this.util.isValidHex(params.link)) {
+                      this.linkFormControl.setValue(params.link);
+                  }
+                  this.blockSignExpand = true;
+              }
+          });
         });
     }
 
     async goSignMessage(): Promise<void> {
         const message: string = this.messageFormControl.value;
-        if (!message.startsWith("message-")) return;
+        if (!message.startsWith("message-") || message.length === 32) return;
         let accountIndex: number = this.addressFormControl.value;
         this.messageSignature = await this.transactionService.messageSign(message, accountIndex);
     }
@@ -61,8 +141,68 @@ export class SigningComponent {
         }, 690);
     }
 
+    copyBlockSignature(): void {
+        this.util.clipboardCopy(this.blockSignature);
+        this.hasCopiedBlockSignature = true;
+        setTimeout(() => {
+            this.hasCopiedBlockSignature = false;
+        }, 690);
+    }
+
+    verifySign(): void {
+        let signerAddress = this.signerFormControl.value;
+        if (!this.util.isValidAddress(signerAddress)) return;
+        let message = this.verifyMessageFormControl.value;
+        let sign = this.verifySignFormControl.value;
+        if (signerAddress === "" || message === "" || sign === "") return;
+        let valid: boolean;
+        try {
+          valid = this.transactionService.verifySign(signerAddress, message, sign);
+        } catch (e) {
+          valid = false;
+        }
+        if (valid) {
+            this.verify_button_text = "Valid";
+            this.verify_button_color = "accent";
+        } else {
+            this.verify_button_text = "Invalid";
+            this.verify_button_color = "warn";
+        }
+        setTimeout(() => {
+            this.verify_button_text = "Verify";
+            this.verify_button_color = "primary";
+        }, 1200);
+    }
+
+    async goSignBlock(): Promise<void> {
+        let accountIndex: number = this.addressBlockFormControl.value;
+        let previous: string = this.previousFormControl.value;
+        if (previous.length !== 64 || !this.util.isValidHex(previous)) return;
+        let representative: string = this.representativeFormControl.value;
+        if (!this.util.isValidAddress(representative)) return;
+        let rawBalance: string = this.balanceFormControl.value;
+        if (isNaN(Number(rawBalance))) return;
+        let link: string = this.linkFormControl.value;
+        if (link.length !== 64 || !this.util.isValidHex(link)) return;
+        const block: TransactionBlock = {
+            type: 'state',
+            account: this.store.accounts.find((item) => item.index === accountIndex).fullAddress,
+            previous,
+            representative,
+            balance: rawBalance,
+            link,
+            signature: '',
+            work: undefined,
+        };
+        this.blockSignature = await this.transactionService.blockSign(block, accountIndex);
+    }
+
     toggleMessageSignExpand(): void {
         this.messageSignExpand = this.messageSignExpand ? false : true;
+    }
+
+    toggleMessageVerifyExpand(): void {
+        this.messageVerifyExpand = this.messageVerifyExpand ? false : true;
     }
 
     toggleBlockSignExpand(): void {

--- a/src/app/services/transaction.service.ts
+++ b/src/app/services/transaction.service.ts
@@ -22,10 +22,10 @@ const signBlock = async (privateKey: string, block: TransactionBlock): Promise<s
     await window.bananocoinBananojs.BananoUtil.sign(privateKey, block);
 
 const signMessage = (privateKey: string, message: string): string =>
-    window.bananocoinBananojs.BananoUtil.signMessage(privateKey, message)
+    window.bananocoinBananojs.BananoUtil.signMessage(privateKey, message);
 
 const verifyMessage = (publicKey: string, message: string, signature: string): boolean =>
-    window.bananocoinBananojs.BananoUtil.verifyMessage(publicKey, message, signature)
+    window.bananocoinBananojs.BananoUtil.verifyMessage(publicKey, message, signature);
 
 const getPublicKeyFromPrivateKey = (privateKey: string): Promise<string> =>
     window.bananocoinBananojs.BananoUtil.getPublicKey(privateKey);

--- a/src/app/services/transaction.service.ts
+++ b/src/app/services/transaction.service.ts
@@ -21,8 +21,11 @@ const getAmountPartsFromRaw = (amountRawStr: string): any =>
 const signBlock = async (privateKey: string, block: TransactionBlock): Promise<string> =>
     await window.bananocoinBananojs.BananoUtil.sign(privateKey, block);
 
-const signMessage = (privateKey: string, message: string): Promise<string> =>
+const signMessage = (privateKey: string, message: string): string =>
     window.bananocoinBananojs.BananoUtil.signMessage(privateKey, message)
+
+const verifyMessage = (publicKey: string, message: string, signature: string): boolean =>
+    window.bananocoinBananojs.BananoUtil.verifyMessage(publicKey, message, signature)
 
 const getPublicKeyFromPrivateKey = (privateKey: string): Promise<string> =>
     window.bananocoinBananojs.BananoUtil.getPublicKey(privateKey);
@@ -243,8 +246,12 @@ export class TransactionService {
     /** Not transaction, but signs message */
     async messageSign(message: string, accountIndex: number): Promise<string> {
         const { privateKey } = await this._getEssentials(accountIndex);
-        //ideally this error is never fired, since message- should be enforced on the interface
-        if (!message.startsWith("message-")) Promise.reject(new Error("Message to sign must start with `message-`"));
         return signMessage(privateKey, message);
+    }
+
+    /** Verify signature is valid */
+    verifySign(address: string, message: string, sign: string): boolean {
+        const publicKey = getPublicKeyFromAccount(address);
+        return verifyMessage(publicKey, message, sign);
     }
 }

--- a/src/app/services/transaction.service.ts
+++ b/src/app/services/transaction.service.ts
@@ -21,6 +21,9 @@ const getAmountPartsFromRaw = (amountRawStr: string): any =>
 const signBlock = async (privateKey: string, block: TransactionBlock): Promise<string> =>
     await window.bananocoinBananojs.BananoUtil.sign(privateKey, block);
 
+const signMessage = (privateKey: string, message: string): Promise<string> =>
+    window.bananocoinBananojs.BananoUtil.signMessage(privateKey, message)
+
 const getPublicKeyFromPrivateKey = (privateKey: string): Promise<string> =>
     window.bananocoinBananojs.BananoUtil.getPublicKey(privateKey);
 
@@ -218,5 +221,30 @@ export class TransactionService {
             console.error(err);
             return Promise.reject(err);
         }
+    }
+
+    /** Not transaction, but signs block */
+    async blockSign(block: TransactionBlock, accountIndex: number): Promise<string> {
+        const { privateKey, accountInfo } = await this._getEssentials(accountIndex);
+        //we are getting the signature, but signature is required, so block.signature === ""
+        //fill in defaults
+        if (!block.account) {
+            block.account = accountInfo.fullAddress;
+        }
+        if (!block.previous) {
+            block.previous = accountInfo.frontier;
+        }
+        if (!block.representative) {
+            block.representative = accountInfo.representative;
+        }
+        return await signBlock(privateKey, block);
+    }
+
+    /** Not transaction, but signs message */
+    async messageSign(message: string, accountIndex: number): Promise<string> {
+        const { privateKey } = await this._getEssentials(accountIndex);
+        //ideally this error is never fired, since message- should be enforced on the interface
+        if (!message.startsWith("message-")) Promise.reject(new Error("Message to sign must start with `message-`"));
+        return signMessage(privateKey, message);
     }
 }

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -77,7 +77,7 @@ export class UtilService {
     }
 
     isValidHex(hex: string): boolean {
-        let validHexChars: string[] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
+        const validHexChars: string[] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
         return hex.split('').every((value) => validHexChars.includes(value.toUpperCase()));
     }
 

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -76,6 +76,11 @@ export class UtilService {
         return address && address.length === 64 && address.startsWith('ban_');
     }
 
+    isValidHex(hex: string): boolean {
+        let validHexChars: string[] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
+        return hex.split('').every((value) => validHexChars.includes(value.toUpperCase()));
+    }
+
     matches(a: number, b: number): boolean {
         return Number(a) === Number(b);
     }

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -77,7 +77,24 @@ export class UtilService {
     }
 
     isValidHex(hex: string): boolean {
-        const validHexChars: string[] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
+        const validHexChars: string[] = [
+            '0',
+            '1',
+            '2',
+            '3',
+            '4',
+            '5',
+            '6',
+            '7',
+            '8',
+            '9',
+            'A',
+            'B',
+            'C',
+            'D',
+            'E',
+            'F',
+        ];
         return hex.split('').every((value) => validHexChars.includes(value.toUpperCase()));
     }
 


### PR DESCRIPTION
Adds dedicated signing page under "Advanced" that allows
- Signing messages with accounts (doesn't work with ledger)
- Verifying messages
- Signing blocks
- Query params for autofilling message signing and block signing (eg: `http://localhost:4200/signing?request=block_sign&address=ban_3yh77j55mscazq9eksiq7a5oxnrgmn8izswsabmecdi74of68ds8do835jo6&previous=56C14E36E99FB535FD358FD7C5F038D8BB5DBD578F2EECEB53FD214BC0D9FE1D&balance=90000000000000000000000000000&representative=ban_3batmanuenphd7osrez9c45b3uqw9d9u81ne8xa6m43e1py56y9p48ap69zg&link=023BC54D1B808218E49739A803981C9631F100313B4E0D9DEA0870C70795B437` or `http://localhost:4200/signing?request=message_sign&address=ban_3yh77j55mscazq9eksiq7a5oxnrgmn8izswsabmecdi74of68ds8do835jo6&message=message-I%20consent%20to%20rugpull`)

Tested locally, but code is probably messy. Some things like message verification is kinda weird UX wise (I have the button changing text based on success/failure, failure also changes colour), but I don't know what to do instead.