### PR TITLE
4.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 -  Changed refresh logic post-transaction; only refresh the account which performed a receive, send, or change transaction rather than all loaded accounts.  If the active account sent a transaction to another account which is loaded on the dashboard, the recipient account is also updated.
+-  Disabled auto-receive for ledger users; hide from settings page and do not show overlay.
 
 ## v4.13.0 (March 13, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v4.14.0 (March 15, 2024)
+## v4.14.0 (March 16, 2024)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v4.14.0 (March 15, 2024)
+
+### Changed
+
+-  Changed refresh logic post-transaction; only refresh the account which performed a receive, send, or change transaction rather than all loaded accounts.  If the active account sent a transaction to another account which is loaded on the dashboard, the recipient account is also updated.
+
 ## v4.13.0 (March 13, 2024)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thebananostand",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --open --host 0.0.0.0",

--- a/src/app/overlays/actions/api-request/api-request.component.ts
+++ b/src/app/overlays/actions/api-request/api-request.component.ts
@@ -292,7 +292,11 @@ export class ApiRequestComponent {
                     this.txHash = hash;
                     this.hasSuccess = true;
                     this.isLoading = false;
-                    TRANSACTION_COMPLETED_SUCCESS.next(hash);
+                    TRANSACTION_COMPLETED_SUCCESS.next({
+                        txHash: hash,
+                        recipient: this.actionAddress,
+                        accountIndex: selectedAccount.index,
+                    });
                 })
                 .catch((err) => {
                     console.error(err);
@@ -306,7 +310,10 @@ export class ApiRequestComponent {
                     this.txHash = hash;
                     this.hasSuccess = true;
                     this.isLoading = false;
-                    TRANSACTION_COMPLETED_SUCCESS.next(hash);
+                    TRANSACTION_COMPLETED_SUCCESS.next({
+                        txHash: hash,
+                        accountIndex: selectedAccount.index,
+                    });
                 })
                 .catch((err) => {
                     console.error(err);

--- a/src/app/overlays/actions/change-rep/change-rep.component.ts
+++ b/src/app/overlays/actions/change-rep/change-rep.component.ts
@@ -298,7 +298,10 @@ export class ChangeRepComponent implements OnInit {
                 this.txHash = hash;
                 this.hasSuccess = true;
                 this.isChangingRepresentative = false;
-                TRANSACTION_COMPLETED_SUCCESS.next(hash);
+                TRANSACTION_COMPLETED_SUCCESS.next({
+                    txHash: hash,
+                    accountIndex: this.data.index,
+                });
             })
             .catch((err) => {
                 console.error(err);

--- a/src/app/overlays/actions/receive/receive.component.ts
+++ b/src/app/overlays/actions/receive/receive.component.ts
@@ -204,7 +204,9 @@ export class ReceiveComponent implements OnInit {
                 return;
             }
         }
-        TRANSACTION_COMPLETED_SUCCESS.next(undefined);
+        TRANSACTION_COMPLETED_SUCCESS.next({
+            accountIndex: this.data.blocks[0].accountIndex,
+        });
         if (this.data.refreshDashboard) {
             REFRESH_DASHBOARD_ACCOUNTS.next();
         }

--- a/src/app/overlays/actions/send/send.component.ts
+++ b/src/app/overlays/actions/send/send.component.ts
@@ -391,7 +391,11 @@ export class SendComponent implements OnInit, OnDestroy {
                 this.txHash = hash;
                 this.hasSuccess = true;
                 this.isProcessingTx = false;
-                TRANSACTION_COMPLETED_SUCCESS.next(hash);
+                TRANSACTION_COMPLETED_SUCCESS.next({
+                    txHash: hash,
+                    accountIndex: this.data.index,
+                    recipient: this.recipient,
+                });
             })
             .catch(() => {
                 this.hasSuccess = false;

--- a/src/app/pages/account/account.component.ts
+++ b/src/app/pages/account/account.component.ts
@@ -6,7 +6,6 @@ import { UtilService } from '@app/services/util.service';
 import { SpyglassService } from '@app/services/spyglass.service';
 import { AccountService } from '@app/services/account.service';
 import { AccountOverview } from '@app/types/AccountOverview';
-import { ThemeService } from '@app/services/theme.service';
 import { RpcService } from '@app/services/rpc.service';
 import { ViewportService } from '@app/services/viewport.service';
 import { MatBottomSheet } from '@angular/material/bottom-sheet';
@@ -72,7 +71,6 @@ export class AccountComponent implements OnInit, OnDestroy {
         private readonly _sheet: MatBottomSheet,
         private readonly _ref: ChangeDetectorRef,
         private readonly _rpcService: RpcService,
-        private readonly _themeService: ThemeService,
         private readonly _accountService: AccountService,
         private readonly _spyglassService: SpyglassService,
         private readonly _appStateService: AppStateService

--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -273,16 +273,18 @@ import { AddSpyglassDialogComponent } from '@app/overlays/dialogs/add-spyglass/a
                                 type="number"
                             />
                         </mat-form-field>
-                        <mat-divider></mat-divider>
-                        <div class="mat-overline" style="margin-top: 16px">Auto-Receive Incoming Transactions</div>
-                        <div class="mat-body-2" style="margin-bottom: 24px">
-                            Incoming transactions will be automatically received when the wallet is unlocked.
-                        </div>
-                        <mat-slide-toggle
-                            (change)="toggleAutoReceiveIncomingTransactions($event)"
-                            [checked]="isEnableAutoReceiveFeature"
-                            >Enable</mat-slide-toggle
-                        >
+                        <ng-container *ngIf="showAutoReceiveToggle()">
+                            <mat-divider></mat-divider>
+                            <div class="mat-overline" style="margin-top: 16px">Auto-Receive Incoming Transactions</div>
+                            <div class="mat-body-2" style="margin-bottom: 24px">
+                                Incoming transactions will be automatically received when the wallet is unlocked.
+                            </div>
+                            <mat-slide-toggle
+                                (change)="toggleAutoReceiveIncomingTransactions($event)"
+                                [checked]="isEnableAutoReceiveFeature"
+                                >Enable</mat-slide-toggle
+                            >
+                        </ng-container>
                     </mat-card>
                 </div>
             </div>
@@ -326,6 +328,9 @@ export class SettingsPageComponent implements OnInit {
         this.minimumThreshold = this._appStateService.store.getValue().minimumBananoThreshold;
     }
 
+    showAutoReceiveToggle(): boolean {
+        return this._appStateService.store.getValue().hasUnlockedSecret;
+    }
     back(): void {
         this._location.back();
     }

--- a/src/app/services/wallet-events.service.ts
+++ b/src/app/services/wallet-events.service.ts
@@ -259,7 +259,10 @@ export class WalletEventsService {
         });
 
         AUTO_RECEIVE_ALL.subscribe(() => {
-            if (!this.store.isEnableAutoReceiveFeature && this.store.hasUnlockedSecret) {
+            if (!this.store.isEnableAutoReceiveFeature) {
+                return;
+            }
+            if (!this.store.hasUnlockedSecret) {
                 return;
             }
             if (this.store.isAutoReceivingTransactions) {


### PR DESCRIPTION
## v4.14.0 (March 16, 2024)

### Changed

-  Changed refresh logic post-transaction; only refresh the account which performed a receive, send, or change transaction rather than all loaded accounts.  If the active account sent a transaction to another account which is loaded on the dashboard, the recipient account is also updated.
-  Disabled auto-receive for ledger users; hide from settings page and do not show overlay.