### PR TITLE
4.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v4.17.1  (November 3, 2024)
+
+### Added
+
+-  Added two BNS TLDs to the default mapping BNS.
+
 ## v4.17.0  (October 14, 2024)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thebananostand",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --open --host 0.0.0.0",


### PR DESCRIPTION
## v4.17.1  (November 3, 2024)

### Added

-  Added two BNS TLDs to the default mapping BNS.
