### PR TITLE
Feature/Default TLDs persist and non-removable, non-editable

### DIFF
--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -21,6 +21,7 @@ import {
 import { MatRadioChange } from '@angular/material/radio';
 import { CurrencyConversionService } from '@app/services/currency-conversion.service';
 import { AppStateService } from '@app/services/app-state.service';
+import { BnsService } from '@app/services/bns.service';
 import { MatSelectChange } from '@angular/material/select';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { AddRpcBottomSheetComponent } from '@app/overlays/bottom-sheet/add-rpc/add-rpc-bottom-sheet.component';
@@ -265,6 +266,7 @@ import { AddTldDialogComponent } from '@app/overlays/dialogs/add-tld/add-tld-dia
                                     [matTooltip]="'Remove ' + tld.key"
                                     color="warn"
                                     (click)="removeTld(tld.key)"
+                                    *ngIf="isNotDefaultBnsTld(tld.key)"
                                 >
                                     <mat-icon color="warn">clear</mat-icon>
                                 </button>
@@ -346,6 +348,7 @@ export class SettingsPageComponent implements OnInit {
         private readonly _location: Location,
         private readonly _sheet: MatBottomSheet,
         private readonly _appStateService: AppStateService,
+        private readonly _bnsService: BnsService,
         public datasourceService: DatasourceService,
         public currencyConversionService: CurrencyConversionService
     ) {
@@ -376,6 +379,10 @@ export class SettingsPageComponent implements OnInit {
     }
     back(): void {
         this._location.back();
+    }
+
+    isNotDefaultBnsTld(tld: string): boolean {
+        return this._bnsService.getDefaultTlds()[tld] === undefined;
     }
 
     openChangePasswordOverlay(): void {

--- a/src/app/services/bns.service.ts
+++ b/src/app/services/bns.service.ts
@@ -49,4 +49,12 @@ export class BnsService {
             return [domain, tld];
         }
     }
+
+    getDefaultTlds(): Record<string, `ban_${string}`> {
+        return {
+            mictest: 'ban_1dzpfrgi8t4byzmdeidh57p14h5jwbursf1t3ztbmeqnqqdcbpgp9x8j3cw6',
+            jtv: 'ban_3gipeswotbnyemcc1dejyhy5a1zfgj35kw356dommbx4rdochiteajcsay56',
+            ban: 'ban_1fdo6b4bqm6pp1w55duuqw5ebz455975o4qcp8of85fjcdw9qhuzxsd3tjb9',
+        };
+    }
 }

--- a/src/app/services/wallet-storage.service.ts
+++ b/src/app/services/wallet-storage.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { AppStateService, AppStore } from '@app/services/app-state.service';
 import { AccountOverview } from '@app/types/AccountOverview';
 import { AddressBookEntry } from '@app/types/AddressBookEntry';
+import { BnsService } from '@app/services/bns.service';
 import { ViewportService } from '@app/services/viewport.service';
 
 export type LocalStorageWallet = {
@@ -35,7 +36,11 @@ const USER_AUTO_RECEIVE_FUNDS = 'bananostand_userAutoReceiveTransactions';
 export class WalletStorageService {
     store: AppStore;
 
-    constructor(private readonly _vp: ViewportService, private readonly _appStateService: AppStateService) {
+    constructor(
+        private readonly _vp: ViewportService,
+        private readonly _appStateService: AppStateService,
+        private readonly _bnsService: BnsService
+    ) {
         this._appStateService.store.subscribe((store) => {
             this.store = store;
         });
@@ -250,15 +255,10 @@ export class WalletStorageService {
     }
 
     readTlds(): Record<string, string> {
-        const json = window.localStorage.getItem(TLDS);
-        const tldEntries = json
-            ? JSON.parse(json)
-            : {
-                  mictest: 'ban_1dzpfrgi8t4byzmdeidh57p14h5jwbursf1t3ztbmeqnqqdcbpgp9x8j3cw6',
-                  jtv: 'ban_3gipeswotbnyemcc1dejyhy5a1zfgj35kw356dommbx4rdochiteajcsay56',
-                  ban: 'ban_1fdo6b4bqm6pp1w55duuqw5ebz455975o4qcp8of85fjcdw9qhuzxsd3tjb9',
-              };
-        return tldEntries;
+        const defaultTldEntries = this._bnsService.getDefaultTlds();
+        const json = JSON.parse(window.localStorage.getItem(TLDS)) ?? {};
+        //ie, default tlds cannot be overwritten or deleted
+        return { ...json, ...defaultTldEntries };
     }
 
     /** Reads from local storage, defaults to USD. */


### PR DESCRIPTION
Make default TLDs persist and non-removable/non-editable. Some people are missing the `.ban` TLD, this should also fix that.